### PR TITLE
missing methods Bouncer_Backend_Memcache::getAgentsIndexFingerprint and Bouncer_Backend_Memcache::getAgentsIndexHost

### DIFF
--- a/Backend/Memcache.php
+++ b/Backend/Memcache.php
@@ -99,6 +99,20 @@ class Bouncer_Backend_Memcache
         return $agents;
     }
 
+    public static function getAgentsIndexFingerprint($fingerprint, $namespace = '')
+    {
+        $indexKey = empty($namespace) ? "agents-$fingerprint" : "agents-$fingerprint-$namespace";
+        $agentsIndex = self::get($indexKey);
+        return $agentsIndex;
+    }
+
+    public static function getAgentsIndexHost($haddr, $namespace = '')
+    {
+        $indexKey = empty($namespace) ? "agents-$haddr" : "agents-$haddr-$namespace";
+        $agentsIndex = self::get($indexKey);
+        return $agentsIndex;
+    }
+
     public static function countAgentsFingerprint($fingerprint, $namespace = '')
     {
         return 0;


### PR DESCRIPTION
Some methods were missing in the memcache backend class. The patch fixes the bug.
