### PR TITLE
Allow newer patches to symfony/http-foundation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+vendor/
+composer.lock

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "require": {
         "php" : ">=5.3.9",
         "monolog/monolog": "~1.19.0",
-        "symfony/http-foundation": "2.7.10"
+        "symfony/http-foundation": "~2.7.10"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Change the composer symfony/http-foundation PATCH version to allow newer patches. Right now we can not install it in our Symfony application due to a version number mismatch.